### PR TITLE
feat: 시간표 XML을 가져와 파싱, Ics 형식으로 변환하는 코드 작성

### DIFF
--- a/src/main/java/dev/whteb/everyCalendar/Configuration/XmlParseConfig.java
+++ b/src/main/java/dev/whteb/everyCalendar/Configuration/XmlParseConfig.java
@@ -1,0 +1,19 @@
+package dev.whteb.everyCalendar.Configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+@Configuration
+public class XmlParseConfig {
+
+    @Bean
+    public DocumentBuilder documentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        return factory.newDocumentBuilder();
+    }
+
+}

--- a/src/main/java/dev/whteb/everyCalendar/DTO/EventDTO.java
+++ b/src/main/java/dev/whteb/everyCalendar/DTO/EventDTO.java
@@ -1,0 +1,14 @@
+package dev.whteb.everyCalendar.DTO;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class EventDTO {
+    String name;
+    Long startTime;
+    Long endTime;
+    Integer weekDay;
+    String place;
+}

--- a/src/main/java/dev/whteb/everyCalendar/Provider/DateProvider.java
+++ b/src/main/java/dev/whteb/everyCalendar/Provider/DateProvider.java
@@ -1,0 +1,28 @@
+package dev.whteb.everyCalendar.Provider;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+
+@Component
+public class DateProvider {
+    public Date findNearestWeekDay(int weekDay, Date startDate) {
+        Calendar cal = Calendar.getInstance(Locale.KOREA);
+        cal.setTime(startDate);
+
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.clear(Calendar.MINUTE);
+        cal.clear(Calendar.SECOND);
+        cal.clear(Calendar.MILLISECOND);
+
+        cal.set(Calendar.DAY_OF_WEEK, weekDay);
+
+        if(cal.getTime().getTime() < startDate.getTime()) {
+            cal.add(Calendar.WEEK_OF_MONTH, 1);
+        }
+
+        return cal.getTime();
+    }
+}

--- a/src/main/java/dev/whteb/everyCalendar/Service/EveryCalendarService.java
+++ b/src/main/java/dev/whteb/everyCalendar/Service/EveryCalendarService.java
@@ -1,0 +1,124 @@
+package dev.whteb.everyCalendar.Service;
+
+import dev.whteb.everyCalendar.DTO.EventDTO;
+import dev.whteb.everyCalendar.Provider.DateProvider;
+import lombok.RequiredArgsConstructor;
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.*;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.*;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EveryCalendarService {
+    private final DateProvider dateProvider;
+    private final DocumentBuilder xmlParser;
+    private HttpURLConnection getConn(String urlString, String method) throws IOException {
+        URL url = new URL(urlString);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+        conn.setRequestProperty("Connection", "keep-alive");
+        conn.setRequestProperty("Pragma", "no-cache");
+        conn.setRequestProperty("Host", "api.everytime.kr");
+        conn.setRequestProperty("Origin", "https://everytime.kr");
+        conn.setRequestProperty("Referer", "https://everytime.kr");
+        conn.setRequestProperty("User-Agent",  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36");
+        conn.setDoOutput(true);
+        conn.setRequestMethod(method);
+        return conn;
+    }
+
+    public String createIcsString(String identifier, Date startDate, Date endDate) throws Exception {
+        Calendar calendar = new Calendar();
+
+        String xml = getXmlFromEverytime(identifier);
+        InputSource source = new InputSource(new StringReader(xml));
+        Document doc = xmlParser.parse(source);
+        Element root = doc.getDocumentElement();
+
+        List<EventDTO> lectures = extractData(root);
+
+        lectures.forEach(l -> {
+            Date nearestDay = dateProvider.findNearestWeekDay((l.getWeekDay() + 2) % 7, startDate);
+
+            calendar.add(new VEvent()
+                    .withProperty(new Summary(l.getName()))
+                    .withProperty(new Location(l.getPlace()))
+                    .withProperty(new DtStart<>(Instant.ofEpochMilli(nearestDay.getTime() + l.getStartTime()) ))
+                    .withProperty(new DtEnd<>(Instant.ofEpochMilli(nearestDay.getTime() + l.getEndTime())))
+                    .withProperty(new RRule<>("FREQ=WEEKLY;UNTIL=" + endDate.toInstant().plus(1, ChronoUnit.DAYS).toString().replaceAll("[:-]", "")))
+                    .getFluentTarget()
+            );
+        });
+
+        return calendar.toString();
+    }
+
+    private String getXmlFromEverytime(String identifier) throws Exception {
+        HttpURLConnection conn = getConn("https://api.everytime.kr/find/timetable/table/friend?friendInfo=true&identifier=" + identifier, "POST");
+
+        int responseCode = conn.getResponseCode();
+
+        if (responseCode != 200) {
+            throw new Exception();
+        }
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while ((line = br.readLine()) != null) {
+            sb.append(line);
+        }
+
+        return sb.toString();
+    }
+
+    private List<EventDTO> extractData(Element root) {
+
+        ArrayList<EventDTO> lectures = new ArrayList<>();
+
+        NodeList nList = root.getElementsByTagName("subject");
+        for(int i = 0; i<nList.getLength(); ++i) {
+            Element element = (Element) nList.item(i);
+            String name =  getAttributeValue(element.getElementsByTagName("name").item(0), "value");
+
+            NodeList dataList = element.getElementsByTagName("data");
+            for(int j = 0; j < dataList.getLength(); ++j) {
+                Node data = dataList.item(j);
+
+                lectures.add(
+                    EventDTO.builder()
+                            .name(name)
+                            .startTime(Integer.parseInt(getAttributeValue(data, "starttime")) * 5 * 60 * 1000L)
+                            .endTime(Integer.parseInt(getAttributeValue(data, "endtime")) * 5 * 60 * 1000L)
+                            .weekDay(Integer.parseInt(getAttributeValue(data, "day")))
+                            .place(getAttributeValue(data, "place"))
+                            .build()
+                );
+            }
+        }
+
+
+        return lectures;
+    }
+
+    private String getAttributeValue(Node node, String name) {
+        NamedNodeMap attributes = node.getAttributes();
+        return attributes.getNamedItem(name).getNodeValue();
+    }
+}


### PR DESCRIPTION
## 변경점
- DateProvider: 요일을 파라미터로 받아 기간 내에 가장 가까운 해당 요일의 Date를 반환하는 findNearestWeekDay() 작성
- XmlParseConfig: Xml 파싱에 사용할 DocumentBuilder Bean 등록
- EveryCalendarService: 에타 api로부터 시간표 XML을 받아와 이를 캘린더 형식으로 변환하는 createIcsString() 작성
- EveryCalendarService: 에타 api로부터 시간표 XML을 받아오는 getXmlFromEverytime() 작성
- EventDTO: ICS 형식 파일에 저장해야 하는 데이터를 보관하는 DTO 작성
- EveryCalendarService: XML 데이터로부터 EventDTO 데이터를 추출하는 extractData() 작성