### PR TITLE
ref: EveryCalendarService 메서드 책임 분리 및 재정의

### DIFF
--- a/src/main/java/dev/whteb/everyCalendar/Controller/EveryCalendarController.java
+++ b/src/main/java/dev/whteb/everyCalendar/Controller/EveryCalendarController.java
@@ -38,7 +38,7 @@ public class EveryCalendarController {
 
         String identifier = matcher.group();
 
-        String ics = everyCalendarService.createIcsString(identifier, getIcsDTO.getFrom(), getIcsDTO.getTo());
+        String ics = everyCalendarService.generateCalendar(identifier, getIcsDTO.getFrom(), getIcsDTO.getTo());
         redirectAttributes.addFlashAttribute("ics", ics);
 
         return "redirect:/success";

--- a/src/main/java/dev/whteb/everyCalendar/Service/EveryCalendarService.java
+++ b/src/main/java/dev/whteb/everyCalendar/Service/EveryCalendarService.java
@@ -3,6 +3,7 @@ package dev.whteb.everyCalendar.Service;
 import dev.whteb.everyCalendar.DTO.EventDTO;
 import dev.whteb.everyCalendar.DTO.response.ResponseDTO;
 import dev.whteb.everyCalendar.Provider.DateProvider;
+import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 import lombok.RequiredArgsConstructor;
 import net.fortuna.ical4j.model.Calendar;
@@ -12,7 +13,6 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.xml.sax.InputSource;
 
 import java.io.StringReader;
 import java.net.URI;
@@ -30,12 +30,18 @@ public class EveryCalendarService {
     private final HttpHeaders mockHttpHeaders;
     private final Unmarshaller unmarshaller;
 
-    public String createIcsString(String identifier, Date startDate, Date endDate) throws Exception {
+    public String generateCalendar(String identifier, Date startDate, Date endDate) throws Exception {
+        ResponseDTO response = requestTimetable(identifier);
+        List<EventDTO> lectures = response.convertToEvents();
+
+        Calendar lectureCalendar = createWeeklyCalendarBetween(lectures, startDate, endDate);
+        return lectureCalendar.toString();
+    }
+
+    private Calendar createWeeklyCalendarBetween(List<EventDTO> events, Date startDate, Date endDate){
         Calendar calendar = new Calendar();
 
-        List<EventDTO> lectures = getLecturesFromEverytime(identifier);
-
-        lectures.forEach(l -> {
+        events.forEach(l -> {
             Date nearestDay = dateProvider.findNearestWeekDay((l.getWeekDay() + 2) % 7, startDate);
 
             calendar.add(new VEvent()
@@ -48,10 +54,10 @@ public class EveryCalendarService {
             );
         });
 
-        return calendar.toString();
+        return calendar;
     }
 
-    private List<EventDTO> getLecturesFromEverytime(String identifier) throws Exception {
+    private ResponseDTO requestTimetable(String identifier) throws Exception {
 
         URI uri = UriComponentsBuilder
                 .fromUriString("https://api.everytime.kr")
@@ -66,16 +72,16 @@ public class EveryCalendarService {
 
         if (response.getStatusCode() != HttpStatus.OK) throw new Exception("서버가 응답하지 않습니다.");
 
-
         String body = response.getBody();
-
-        StringReader bodyReader = new StringReader(body);
-
-        ResponseDTO responseDTO = (ResponseDTO) unmarshaller.unmarshal(new InputSource(bodyReader));
+        ResponseDTO responseDTO = parseTimetable(body);
 
         if(responseDTO.getTable() == null) throw new Exception("시간표 URL이 올바르지 않습니다.");
         if(responseDTO.getTable().getSubjects() == null) throw new Exception("시간표가 공개되어 있지 않거나, 등록된 강의가 없습니다.");
 
-        return responseDTO.convertToEvents();
+        return responseDTO;
+    }
+
+    private ResponseDTO parseTimetable(String xml) throws JAXBException {
+        return (ResponseDTO) unmarshaller.unmarshal(new StringReader(xml));
     }
 }

--- a/src/test/java/dev/whteb/everyCalendar/Service/EveryCalendarServiceTest.java
+++ b/src/test/java/dev/whteb/everyCalendar/Service/EveryCalendarServiceTest.java
@@ -1,0 +1,79 @@
+package dev.whteb.everyCalendar.Service;
+
+import dev.whteb.everyCalendar.Configuration.RequestConfig;
+import dev.whteb.everyCalendar.DTO.response.ResponseDTO;
+import dev.whteb.everyCalendar.Provider.DateProvider;
+import jakarta.xml.bind.Unmarshaller;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.*;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EveryCalendarServiceTest {
+
+    private static EveryCalendarService everyCalendarService;
+    private static HttpHeaders mockHttpHeaders;
+
+    @BeforeAll
+    static void beforeAll() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(RequestConfig.class);
+        RestTemplate restTemplate = ac.getBean("restTemplate", RestTemplate.class);
+        mockHttpHeaders = ac.getBean("mockHttpHeaders", HttpHeaders.class);
+        Unmarshaller unmarshaller = ac.getBean("unmarshaller", Unmarshaller.class);
+
+        everyCalendarService = new EveryCalendarService(new DateProvider(), restTemplate, mockHttpHeaders, unmarshaller);
+    }
+
+    @Test
+    void ICAL_생성_테스트() {
+        File file = new File("./src/test/resources", "friend.xml");
+        assertThat(file.exists()).isTrue();
+
+        StringBuilder everything = new StringBuilder();
+        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+            String line;
+            while( (line = br.readLine()) != null) {
+                everything.append(line);
+            }
+        } catch(IOException ignored) {}
+
+        System.out.println("everything = " + everything);
+
+        ResponseDTO result = ReflectionTestUtils.invokeMethod(everyCalendarService, "parseTimetable", everything.toString());
+        assertThat(result).isNotNull();
+
+        System.out.println("result = " + result.convertToEvents());
+        assertThat(result.convertToEvents().size()).isEqualTo(8);
+    }
+
+    @Test
+    void 외부_API에_요청을_보내면_403이_발생하지_않는다() {
+        RestTemplate restTemplate = new RestTemplate();
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://api.everytime.kr")
+                .path("/")
+                .encode(StandardCharsets.UTF_8)
+                .build()
+                .toUri();
+
+        Assertions.assertThatThrownBy(
+                () -> restTemplate.exchange(uri, HttpMethod.POST, new HttpEntity<>("", mockHttpHeaders), String.class))
+                .isNotInstanceOf(HttpClientErrorException.Forbidden.class);
+    }
+
+}

--- a/src/test/resources/friend.xml
+++ b/src/test/resources/friend.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+    <table year="2023" semester="1" status="1" identifier="XcpxVWwrOzWS8er2byhX">
+        <subject id="5989595">
+            <internal value="SYB9082-20385"/>
+            <name value="색채심리와현대생활"/>
+            <professor value=""/>
+            <time value=""/>
+            <place value=""/>
+            <credit value="3"/>
+            <closed value="0"/>
+        </subject>
+        <subject id="5990237">
+            <internal value="EEN2004-22995"/>
+            <name value="컴퓨터프로그래밍"/>
+            <professor value="홍길동"/>
+            <time value="월(14:30-16:30),화(15:00-17:00)">
+                <data day="0" starttime="174" endtime="198" place="제1공학관509강의실"/>
+                <data day="1" starttime="180" endtime="204" place="제4공학관IC-PBL실습실"/>
+            </time>
+            <place value="제1공학관509강의실,제4공학관IC-PBL실습실"/>
+            <credit value="3"/>
+            <closed value="0"/>
+        </subject>
+        <subject id="5990403">
+            <internal value="DEE2051-24168"/>
+            <name value="학술영어1:통합"/>
+            <professor value="David"/>
+            <time value="목(11:00-13:00)">
+                <data day="3" starttime="132" endtime="156" place="제1공학관124강의실"/>
+            </time>
+            <place value="제1공학관124강의실"/>
+            <credit value="2"/>
+            <closed value="0"/>
+        </subject>
+        <subject id="5990449">
+            <internal value="VCC2001-22245"/>
+            <name value="IC-PBL과취창업을위한진로탐색"/>
+            <professor value="김철수"/>
+            <time value="시간미지정강좌"/>
+            <place value="비지정()"/>
+            <credit value="1"/>
+            <closed value="0"/>
+        </subject>
+        <subject id="5990529">
+            <internal value="COE3051-22947"/>
+            <name value="공업수학1"/>
+            <professor value="김영희"/>
+            <time value="목(13:00-14:30)">
+                <data day="3" starttime="156" endtime="174" place="제3공학관219강의실"/>
+            </time>
+            <place value="제3공학관219강의실,"/>
+            <credit value="3"/>
+            <closed value="0"/>
+        </subject>
+        <subject id="5990700">
+            <internal value="ELE2003-25081"/>
+            <name value="회로이론"/>
+            <professor value="김민서"/>
+            <time value="목(16:00-18:00),수(15:00-17:00)">
+                <data day="2" starttime="180" endtime="204" place="제1공학관509강의실"/>
+                <data day="3" starttime="192" endtime="216" place="제1공학관401강의실"/>
+            </time>
+            <place value="제1공학관401강의실,제1공학관509강의실"/>
+            <credit value="4"/>
+            <closed value="0"/>
+        </subject>
+        <subject id="5990886">
+            <internal value="PHY3005-24858"/>
+            <name value="전자기학1"/>
+            <professor value="장아름"/>
+            <time value="월(13:00-14:30),화(13:00-14:30)">
+                <data day="0" starttime="156" endtime="174" place="제1공학관504강의실"/>
+                <data day="1" starttime="156" endtime="174" place="제1공학관504강의실"/>
+            </time>
+            <place value="제1공학관504강의실"/>
+            <credit value="3"/>
+            <closed value="0"/>
+        </subject>
+    </table>
+    <user name="김서준" isMine="1" isFriend="0"/>
+    <primaryTables>
+        <primaryTable year="2023" semester="2" identifier="kxhoqe1qP73OKpqRTIej"/>
+        <primaryTable year="2023" semester="1" identifier="XcpxVWwrOzWS6er0ayhX"/>
+    </primaryTables>
+</response>


### PR DESCRIPTION
## 변경점
- EveryCalendarService: createIcsString()을 generateCalendar()로 메서드명 변경
- EveryCalendarService: EventDTO를 바탕으로 Calendar를 생성하는 코드를 createWeeklyCalendarBetween()으로 분리
- EveryCalendarService: getLecturesFromEverytime()을 requestTimetable()로 메서드명 변경
- EveryCalendarService: requestTimetable()에서 responseDTO를 반환하도록 하고 generateCalendar()에서 EventDTO 리스트로 변환하도록 변경
- EveryCalendarService: requestTimetable()에서 파싱 부분을 parseTimetable()로 분리
- EveryCalendarController: EveryCalendarService 변경 사항 반영

issue: #38 