### PR TITLE
chore: 스프링부트 테스트 적용

### DIFF
--- a/src/test/java/dev/whteb/everyCalendar/Provider/DateProviderTest.java
+++ b/src/test/java/dev/whteb/everyCalendar/Provider/DateProviderTest.java
@@ -1,6 +1,5 @@
 package dev.whteb.everyCalendar.Provider;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Calendar;
@@ -11,14 +10,9 @@ import java.util.TimeZone;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DateProviderTest {
-    static Date base;
-    static DateProvider dateProvider;
-    @BeforeAll
-    static void beforeAll() {
-        base = getSpecificDate(2024, Calendar.JANUARY, 5);
-        dateProvider = new DateProvider();
-        System.out.println("base = " + base);
-    }
+
+    Date base = getSpecificDate(2024, Calendar.JANUARY, 5);
+    DateProvider dateProvider = new DateProvider();
 
     @Test
     void 특정_요일_가장_가까운_날짜를_반환한다() {

--- a/src/test/java/dev/whteb/everyCalendar/Service/EveryCalendarServiceTest.java
+++ b/src/test/java/dev/whteb/everyCalendar/Service/EveryCalendarServiceTest.java
@@ -7,6 +7,8 @@ import jakarta.xml.bind.Unmarshaller;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.http.HttpEntity;
@@ -24,20 +26,14 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SpringBootTest
 class EveryCalendarServiceTest {
 
-    private static EveryCalendarService everyCalendarService;
-    private static HttpHeaders mockHttpHeaders;
+    @Autowired
+    EveryCalendarService everyCalendarService;
 
-    @BeforeAll
-    static void beforeAll() {
-        ApplicationContext ac = new AnnotationConfigApplicationContext(RequestConfig.class);
-        RestTemplate restTemplate = ac.getBean("restTemplate", RestTemplate.class);
-        mockHttpHeaders = ac.getBean("mockHttpHeaders", HttpHeaders.class);
-        Unmarshaller unmarshaller = ac.getBean("unmarshaller", Unmarshaller.class);
-
-        everyCalendarService = new EveryCalendarService(new DateProvider(), restTemplate, mockHttpHeaders, unmarshaller);
-    }
+    @Autowired
+    HttpHeaders mockHttpHeaders;
 
     @Test
     void ICAL_생성_테스트() {


### PR DESCRIPTION
## 변경점
- EveryCalendarServiceTest: `@SpringBootTest`를 적용해 테스트에 필요한 빈을 `@Autowired`를 통해 가져오도록 변경
- DateProviderTest: 불필요한 static을 제거 후 선언과 동시에 초기화하도록 변경

issue: #35